### PR TITLE
Update broken tests

### DIFF
--- a/tests/5_array/array_structure_access.alf.json
+++ b/tests/5_array/array_structure_access.alf.json
@@ -1,4 +1,109 @@
-[ {
-  "type" : "UNDEFINED_TYPE",
-  "line" : 9
-} ]
+{
+  "@type" : "Module",
+  "block" : {
+    "@type" : "Block",
+    "statements" : [ {
+      "@type" : "Assignment",
+      "to" : {
+        "@type" : "StructElement",
+        "struct" : {
+          "@type" : "ArrayElement",
+          "array" : {
+            "@type" : "Identifier",
+            "title" : "mySchools",
+            "typeName" : "school_array",
+            "line" : 12
+          },
+          "index" : {
+            "@type" : "Value",
+            "value" : "1",
+            "typeName" : "I64",
+            "line" : 12
+          },
+          "typeName" : "school",
+          "line" : 12
+        },
+        "field" : "name",
+        "typeName" : "String",
+        "line" : 12
+      },
+      "from" : {
+        "@type" : "Value",
+        "value" : "School",
+        "typeName" : "String",
+        "line" : 12
+      },
+      "line" : 12
+    } ],
+    "line" : 3,
+    "scope" : {
+      "@type" : "SymbolTable",
+      "variables" : {
+        "mySchools" : "school_array"
+      },
+      "types" : {
+        "school_array" : {
+          "@type" : "Array",
+          "title" : "school_array",
+          "typeName" : "school",
+          "length" : {
+            "@type" : "BinaryExpression",
+            "left" : {
+              "@type" : "Value",
+              "value" : "9",
+              "typeName" : "I64",
+              "line" : 9
+            },
+            "right" : {
+              "@type" : "Value",
+              "value" : "1",
+              "typeName" : "I64",
+              "line" : 9
+            },
+            "op" : "SUB",
+            "typeName" : "I64",
+            "line" : 9
+          }
+        },
+        "String" : {
+          "@type" : "Str",
+          "title" : "String"
+        },
+        "Boolean" : {
+          "@type" : "Boolean",
+          "title" : "Boolean"
+        },
+        "school" : {
+          "@type" : "Struct",
+          "title" : "school",
+          "properties" : [ {
+            "@type" : "Property",
+            "title" : "name",
+            "typeName" : "String",
+            "defaultValue" : null,
+            "line" : 4
+          }, {
+            "@type" : "Property",
+            "title" : "private",
+            "typeName" : "Boolean",
+            "defaultValue" : null,
+            "line" : 5
+          }, {
+            "@type" : "Property",
+            "title" : "type",
+            "typeName" : "I64",
+            "defaultValue" : null,
+            "line" : 6
+          } ]
+        },
+        "I64" : {
+          "@type" : "Integer",
+          "itype" : "I64",
+          "title" : "I64"
+        }
+      },
+      "functions" : { }
+    }
+  },
+  "line" : 3
+}

--- a/tests/5_array/array_structure_definition.alf.json
+++ b/tests/5_array/array_structure_definition.alf.json
@@ -2,44 +2,12 @@
   "@type" : "Module",
   "block" : {
     "@type" : "Block",
-    "statements" : [ {
-      "@type" : "Assignment",
-      "to" : {
-        "@type" : "StructElement",
-        "struct" : {
-          "@type" : "ArrayElement",
-          "array" : {
-            "@type" : "Identifier",
-            "title" : "mySchools",
-            "typeName" : "school_array",
-            "line" : 12
-          },
-          "index" : {
-            "@type" : "Value",
-            "value" : "1",
-            "typeName" : "I64",
-            "line" : 12
-          },
-          "typeName" : "school",
-          "line" : 12
-        },
-        "field" : "name",
-        "typeName" : "String",
-        "line" : 12
-      },
-      "from" : {
-        "@type" : "Value",
-        "value" : "School",
-        "typeName" : "String",
-        "line" : 12
-      },
-      "line" : 12
-    } ],
+    "statements" : [ ],
     "line" : 3,
     "scope" : {
       "@type" : "SymbolTable",
       "variables" : {
-        "mySchools" : "school_array"
+        "list_of_schools" : "school_array"
       },
       "types" : {
         "school_array" : {

--- a/tests/5_array/array_structure_definition.alf.json
+++ b/tests/5_array/array_structure_definition.alf.json
@@ -1,4 +1,109 @@
-[ {
-  "type" : "UNDEFINED_TYPE",
-  "line" : 9
-} ]
+{
+  "@type" : "Module",
+  "block" : {
+    "@type" : "Block",
+    "statements" : [ {
+      "@type" : "Assignment",
+      "to" : {
+        "@type" : "StructElement",
+        "struct" : {
+          "@type" : "ArrayElement",
+          "array" : {
+            "@type" : "Identifier",
+            "title" : "mySchools",
+            "typeName" : "school_array",
+            "line" : 12
+          },
+          "index" : {
+            "@type" : "Value",
+            "value" : "1",
+            "typeName" : "I64",
+            "line" : 12
+          },
+          "typeName" : "school",
+          "line" : 12
+        },
+        "field" : "name",
+        "typeName" : "String",
+        "line" : 12
+      },
+      "from" : {
+        "@type" : "Value",
+        "value" : "School",
+        "typeName" : "String",
+        "line" : 12
+      },
+      "line" : 12
+    } ],
+    "line" : 3,
+    "scope" : {
+      "@type" : "SymbolTable",
+      "variables" : {
+        "mySchools" : "school_array"
+      },
+      "types" : {
+        "school_array" : {
+          "@type" : "Array",
+          "title" : "school_array",
+          "typeName" : "school",
+          "length" : {
+            "@type" : "BinaryExpression",
+            "left" : {
+              "@type" : "Value",
+              "value" : "9",
+              "typeName" : "I64",
+              "line" : 9
+            },
+            "right" : {
+              "@type" : "Value",
+              "value" : "1",
+              "typeName" : "I64",
+              "line" : 9
+            },
+            "op" : "SUB",
+            "typeName" : "I64",
+            "line" : 9
+          }
+        },
+        "String" : {
+          "@type" : "Str",
+          "title" : "String"
+        },
+        "Boolean" : {
+          "@type" : "Boolean",
+          "title" : "Boolean"
+        },
+        "school" : {
+          "@type" : "Struct",
+          "title" : "school",
+          "properties" : [ {
+            "@type" : "Property",
+            "title" : "name",
+            "typeName" : "String",
+            "defaultValue" : null,
+            "line" : 4
+          }, {
+            "@type" : "Property",
+            "title" : "private",
+            "typeName" : "Boolean",
+            "defaultValue" : null,
+            "line" : 5
+          }, {
+            "@type" : "Property",
+            "title" : "type",
+            "typeName" : "I64",
+            "defaultValue" : null,
+            "line" : 6
+          } ]
+        },
+        "I64" : {
+          "@type" : "Integer",
+          "itype" : "I64",
+          "title" : "I64"
+        }
+      },
+      "functions" : { }
+    }
+  },
+  "line" : 3
+}

--- a/tests/6_error/type_redefine.alf.ast.json
+++ b/tests/6_error/type_redefine.alf.ast.json
@@ -24,7 +24,7 @@
         "properties" : [ {
           "@type" : "Property",
           "title" : "title",
-          "typeName" : "string",
+          "typeName" : "String",
           "defaultValue" : null,
           "line" : 8
         } ]

--- a/tests/7_bonus/class_property.alf.ast.json
+++ b/tests/7_bonus/class_property.alf.ast.json
@@ -16,7 +16,7 @@
         }, {
           "@type" : "Property",
           "title" : "private",
-          "typeName" : "bool",
+          "typeName" : "Boolean",
           "defaultValue" : null,
           "line" : 5
         }, {

--- a/tests/7_bonus/class_property.alf.json
+++ b/tests/7_bonus/class_property.alf.json
@@ -48,7 +48,7 @@
           }, {
             "@type" : "Property",
             "title" : "private",
-            "typeName" : "bool",
+            "typeName" : "Boolean",
             "defaultValue" : null,
             "line" : 5
           }, {

--- a/tests/7_bonus/class_property.alf.json
+++ b/tests/7_bonus/class_property.alf.json
@@ -36,6 +36,10 @@
           "@type" : "Str",
           "title" : "String"
         },
+        "Boolean" : {
+          "@type" : "Boolean",
+          "title" : "Boolean"
+        },
         "school" : {
           "@type" : "Struct",
           "title" : "school",


### PR DESCRIPTION
### Overview

This PR solves the problem with the test results at `5_array/array_structure_access.alf.json` and `5_array/array_structure_definition.alf.json` which were throwing a `UNDEFINED_TYPE` error when they shouldn't have done that (since the structure was previously declared).

### TODO

Need someone else to also make sure I haven't made any errors along the way.

### Author

Signed-off-by: Popescu Adrian [adrian.popescu1005@stud.fils.upb.ro](adrian.popescu1005@stud.fils.upb.ro)